### PR TITLE
add support of ZAdd with args command

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1670,6 +1670,28 @@ var _ = Describe("RedisMock", func() {
 			})
 		})
 
+		It("ZAddArgs", func() {
+			operationIntCmd(clientMock, func() *ExpectedInt {
+				return clientMock.ExpectZAddArgs("zset", redis.ZAddArgs{
+					Members: []redis.Z{
+						{
+							Member: "a",
+							Score:  1,
+						},
+					},
+				})
+			}, func() *redis.IntCmd {
+				return client.ZAddArgs(ctx, "zset", redis.ZAddArgs{
+					Members: []redis.Z{
+						{
+							Member: "a",
+							Score:  1,
+						},
+					},
+				})
+			})
+		})
+
 		It("ZAddNX", func() {
 			operationIntCmd(clientMock, func() *ExpectedInt {
 				return clientMock.ExpectZAddNX("zset", &redis.Z{

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1669,6 +1669,28 @@ var _ = Describe("RedisMock", func() {
 			})
 		})
 
+		It("ZAddArgs", func() {
+			operationIntCmd(clusterMock, func() *ExpectedInt {
+				return clusterMock.ExpectZAddArgs("zset", redis.ZAddArgs{
+					Members: []redis.Z{
+						{
+							Member: "a",
+							Score:  1,
+						},
+					},
+				})
+			}, func() *redis.IntCmd {
+				return client.ZAddArgs(ctx, "zset", redis.ZAddArgs{
+					Members: []redis.Z{
+						{
+							Member: "a",
+							Score:  1,
+						},
+					},
+				})
+			})
+		})
+
 		It("ZAddNX", func() {
 			operationIntCmd(clusterMock, func() *ExpectedInt {
 				return clusterMock.ExpectZAddNX("zset", &redis.Z{

--- a/expect.go
+++ b/expect.go
@@ -176,6 +176,7 @@ type baseMock interface {
 	ExpectBZPopMax(timeout time.Duration, keys ...string) *ExpectedZWithKey
 	ExpectBZPopMin(timeout time.Duration, keys ...string) *ExpectedZWithKey
 	ExpectZAdd(key string, members ...*redis.Z) *ExpectedInt
+	ExpectZAddArgs(key string, args redis.ZAddArgs) *ExpectedInt
 	ExpectZAddNX(key string, members ...*redis.Z) *ExpectedInt
 	ExpectZAddXX(key string, members ...*redis.Z) *ExpectedInt
 	ExpectZAddCh(key string, members ...*redis.Z) *ExpectedInt

--- a/mock.go
+++ b/mock.go
@@ -257,7 +257,9 @@ func (m *mock) compare(isRegexp bool, expect, cmd interface{}) error {
 
 // using map in command leads to disorder, change the command parameter to map[string]interface{}
 // for example:
+//
 //	[mset key1 value1 key2 value2] => [mset map[string]interface{}{"key1": "value1", "key2": "value2"}]
+//
 // return bool, is it handled
 func (m *mock) mapArgs(cmd string, cmdArgs *[]interface{}) bool {
 	var cut int
@@ -1398,6 +1400,13 @@ func (m *mock) ExpectBZPopMin(timeout time.Duration, keys ...string) *ExpectedZW
 func (m *mock) ExpectZAdd(key string, members ...*redis.Z) *ExpectedInt {
 	e := &ExpectedInt{}
 	e.cmd = m.factory.ZAdd(m.ctx, key, members...)
+	m.pushExpect(e)
+	return e
+}
+
+func (m *mock) ExpectZAddArgs(key string, args redis.ZAddArgs) *ExpectedInt {
+	e := &ExpectedInt{}
+	e.cmd = m.factory.ZAddArgs(m.ctx, key, args)
 	m.pushExpect(e)
 	return e
 }


### PR DESCRIPTION
add support of ZAdd with args command

See: https://redis.io/commands/zadd/ and https://pkg.go.dev/github.com/go-redis/redis/v8#ZAddArgs